### PR TITLE
Replace inflow and outflow fields in Transaction with amountMinor

### DIFF
--- a/src/LoonyInternalError.jsx
+++ b/src/LoonyInternalError.jsx
@@ -1,3 +1,4 @@
+// TODO: Move to errors.js.
 export default function LoonyInternalError(message) {
   this.message = `Loony internal error: ${message}`;
 }

--- a/src/MutableTransactionRow.jsx
+++ b/src/MutableTransactionRow.jsx
@@ -35,8 +35,8 @@ export default class MutableTransactionRow extends React.Component {
         payee: this.props.initialTransaction.payee,
         category: this.props.initialTransaction.category,
         memo: this.props.initialTransaction.memo,
-        outflow: this.props.initialTransaction.outflow,
-        inflow: this.props.initialTransaction.inflow,
+        outflow: this.props.initialTransaction.outflow(),
+        inflow: this.props.initialTransaction.inflow(),
       };
     }
 

--- a/src/MutableTransactionRow.jsx
+++ b/src/MutableTransactionRow.jsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 import React from 'react';
 
 import Transaction from './Transaction';
+import errors from './errors';
 
 export default class MutableTransactionRow extends React.Component {
   // Test seam.
@@ -20,6 +21,40 @@ export default class MutableTransactionRow extends React.Component {
       outflow: '',
       inflow: '',
     };
+  }
+
+  static parseAmountMinor(inflowStr, outflowStr) {
+    const inflow = parseFloat(inflowStr);
+    if (inflowStr !== '' && isNaN(inflow)) {
+      throw new errors.ParseError(`inflow is not a number: ${inflowStr}`);
+    }
+    const outflow = parseFloat(outflowStr);
+    if (outflowStr !== '' && isNaN(outflow)) {
+      throw new errors.ParseError(`outflow is not a number: ${outflowStr}`);
+    }
+
+    if (!isNaN(outflow) && !isNaN(inflow) && outflow !== 0 && inflow !== 0) {
+      throw new errors.ParseError(
+        `Both outflow=${outflow} and inflow=${inflow} can't be given`);
+    }
+
+    if (outflow < 0) {
+      throw new errors.ParseError(`outflow can't be negative: ${outflow}`);
+    }
+    if (inflow < 0) {
+      throw new errors.ParseError(`inflow can't be negative: ${outflow}`);
+    }
+
+    if (inflow > 0) {
+      // TODO: Stop using floats for money.
+      // TODO: Support currencies with different minor units.
+      return inflow * 100;
+    } else if (outflow > 0) {
+      // TODO: Stop using floats for money.
+      // TODO: Support currencies with different minor units.
+      return -1 * outflow * 100;
+    }
+    return 0;
   }
 
   constructor(props) {
@@ -58,9 +93,8 @@ export default class MutableTransactionRow extends React.Component {
       payee: this.state.payee,
       category: this.state.category,
       memo: this.state.memo,
-      // TODO: Stop using floats to represent money.
-      outflow: parseFloat(this.state.outflow),
-      inflow: parseFloat(this.state.inflow),
+      amountMinor: MutableTransactionRow.parseAmountMinor(
+        this.state.inflow, this.state.outflow),
     });
 
     this.props.submitHandler(tx);

--- a/src/MutableTransactionRow.jsx
+++ b/src/MutableTransactionRow.jsx
@@ -1,6 +1,5 @@
 import moment from 'moment';
 import React from 'react';
-import uuid from 'uuid';
 
 import Transaction from './Transaction';
 
@@ -10,27 +9,35 @@ export default class MutableTransactionRow extends React.Component {
     return moment().format('YYYY-MM-DD');
   }
 
-  // Test seam.
-  static getUUID() {
-    return uuid.v4();
-  }
-
-  static getEmptyTransaction() {
-    return new Transaction({
-      id: MutableTransactionRow.getUUID(),
-      dateMs: MutableTransactionRow.getDate(),
-    });
+  static getEmptyState() {
+    return {
+      id: null,
+      account: '',
+      date: MutableTransactionRow.getDate(),
+      payee: '',
+      category: '',
+      memo: '',
+      outflow: '',
+      inflow: '',
+    };
   }
 
   constructor(props) {
     super(props);
 
-    this.state = {};
-
     if (this.props.initialTransaction === null) {
-      this.state.transaction = MutableTransactionRow.getEmptyTransaction();
+      this.state = MutableTransactionRow.getEmptyState();
     } else {
-      this.state.transaction = this.props.initialTransaction;
+      this.state = {
+        id: this.props.initialTransaction.id,
+        account: this.props.initialTransaction.account,
+        date: this.props.initialTransaction.prettyDate(),
+        payee: this.props.initialTransaction.payee,
+        category: this.props.initialTransaction.category,
+        memo: this.props.initialTransaction.memo,
+        outflow: this.props.initialTransaction.outflow,
+        inflow: this.props.initialTransaction.inflow,
+      };
     }
 
     this.handleInputChange = this.handleInputChange.bind(this);
@@ -40,26 +47,26 @@ export default class MutableTransactionRow extends React.Component {
   handleInputChange(event) {
     const target = event.target;
     const { name, value } = target;
-    this.setState((prevState) => {
-      const tx = prevState.transaction;
-      tx[name] = value;
-      return { tx };
-    });
+    this.setState({ [name]: value });
   }
 
   handleSubmit() {
-    const tx = this.state.transaction;
-
-    // Parse fields into our actual desired types.
-    tx.dateMs = moment.utc(tx.dateMs, 'YYYY-MM-DD').valueOf();
-    // TODO: Stop using floats to represent money.
-    tx.outflow = parseFloat(tx.outflow);
-    tx.inflow = parseFloat(tx.inflow);
+    const tx = new Transaction({
+      id: this.state.id,
+      account: this.state.account,
+      dateMs: moment.utc(this.state.date, 'YYYY-MM-DD').valueOf(),
+      payee: this.state.payee,
+      category: this.state.category,
+      memo: this.state.memo,
+      // TODO: Stop using floats to represent money.
+      outflow: parseFloat(this.state.outflow),
+      inflow: parseFloat(this.state.inflow),
+    });
 
     this.props.submitHandler(tx);
     // Clear the state so this component can be reused (e.g. by
     // AddTransactionRow).
-    this.state.transaction = MutableTransactionRow.getEmptyTransaction();
+    this.setState(MutableTransactionRow.getEmptyState());
   }
 
   render() {
@@ -72,16 +79,16 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="account"
             placeholder="Account"
-            value={this.state.transaction.account}
+            value={this.state.account}
             onChange={this.handleInputChange}
           />
         </td>
         <td>
           <input
             type="date"
-            name="dateMs"
+            name="date"
             placeholder="Date"
-            value={this.state.transaction.prettyDate()}
+            value={this.state.date}
             onChange={this.handleInputChange}
           />
         </td>
@@ -90,7 +97,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="payee"
             placeholder="Payee"
-            value={this.state.transaction.payee}
+            value={this.state.payee}
             onChange={this.handleInputChange}
           />
         </td>
@@ -99,7 +106,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="category"
             placeholder="Category"
-            value={this.state.transaction.category}
+            value={this.state.category}
             onChange={this.handleInputChange}
           />
         </td>
@@ -108,7 +115,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="memo"
             placeholder="Memo"
-            value={this.state.transaction.memo}
+            value={this.state.memo}
             onChange={this.handleInputChange}
           />
         </td>
@@ -117,7 +124,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="outflow"
             placeholder="Outflow"
-            value={this.state.transaction.outflow}
+            value={this.state.outflow}
             onChange={this.handleInputChange}
           />
         </td>
@@ -126,7 +133,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="inflow"
             placeholder="Inflow"
-            value={this.state.transaction.inflow}
+            value={this.state.inflow}
             onChange={this.handleInputChange}
           />
         </td>

--- a/src/Transaction.jsx
+++ b/src/Transaction.jsx
@@ -1,5 +1,7 @@
 import moment from 'moment';
 
+import LoonyInternalError from './LoonyInternalError';
+
 export default class Transaction {
   constructor({ id = null, account = '', dateMs = 0, payee = '', category = '',
                 memo = '', outflow = 0.0, inflow = 0.0 }) {
@@ -9,13 +11,51 @@ export default class Transaction {
     this.payee = payee;
     this.category = category;
     this.memo = memo;
-    this.outflow = outflow;
-    this.inflow = inflow;
+
+    if (outflow !== 0.0 && inflow !== 0.0) {
+      throw new LoonyInternalError(
+          `Both outflow=${outflow} and inflow=${inflow} can't be specified`);
+    }
+    if (outflow < 0) {
+      throw new LoonyInternalError(`outflow can't be negative: ${outflow}`);
+    }
+    if (inflow < 0) {
+      throw new LoonyInternalError(`inflow can't be negative: ${outflow}`);
+    }
+
+    if (inflow === 0 && outflow === 0) {
+      this.amountMinor = 0;
+    } else if (inflow > 0) {
+      // TODO: Stop using floats for money.
+      this.amountMinor = inflow * 100;
+    } else if (outflow > 0) {
+      // TODO: Stop using floats for money.
+      this.amountMinor = -1 * outflow * 100;
+    } else {
+      throw new LoonyInternalError(
+          `couldn't parse inflow=${inflow} or outflow=${outflow}`);
+    }
   }
 
   prettyDate() {
     // TODO: Do we need to store dates according to the user's desired
     // timezone?
     return moment(this.dateMs).utc().format('YYYY-MM-DD');
+  }
+
+  inflow() {
+    if (this.amountMinor >= 0) {
+      // TODO: Stop using floats for money.
+      return this.amountMinor / 100;
+    }
+    return 0;
+  }
+
+  outflow() {
+    if (this.amountMinor <= 0) {
+      // TODO: Stop using floats for money.
+      return Math.abs(this.amountMinor) / 100;
+    }
+    return 0;
   }
 }

--- a/src/Transaction.jsx
+++ b/src/Transaction.jsx
@@ -1,40 +1,15 @@
 import moment from 'moment';
 
-import LoonyInternalError from './LoonyInternalError';
-
 export default class Transaction {
   constructor({ id = null, account = '', dateMs = 0, payee = '', category = '',
-                memo = '', outflow = 0.0, inflow = 0.0 }) {
+                memo = '', amountMinor = 0.0 }) {
     this.id = id;
     this.account = account;
     this.dateMs = dateMs;
     this.payee = payee;
     this.category = category;
     this.memo = memo;
-
-    if (outflow !== 0.0 && inflow !== 0.0) {
-      throw new LoonyInternalError(
-          `Both outflow=${outflow} and inflow=${inflow} can't be specified`);
-    }
-    if (outflow < 0) {
-      throw new LoonyInternalError(`outflow can't be negative: ${outflow}`);
-    }
-    if (inflow < 0) {
-      throw new LoonyInternalError(`inflow can't be negative: ${outflow}`);
-    }
-
-    if (inflow === 0 && outflow === 0) {
-      this.amountMinor = 0;
-    } else if (inflow > 0) {
-      // TODO: Stop using floats for money.
-      this.amountMinor = inflow * 100;
-    } else if (outflow > 0) {
-      // TODO: Stop using floats for money.
-      this.amountMinor = -1 * outflow * 100;
-    } else {
-      throw new LoonyInternalError(
-          `couldn't parse inflow=${inflow} or outflow=${outflow}`);
-    }
+    this.amountMinor = amountMinor;
   }
 
   prettyDate() {

--- a/src/TransactionRow.jsx
+++ b/src/TransactionRow.jsx
@@ -42,10 +42,10 @@ export default class TransactionRow extends React.Component {
         <td>{this.props.transaction.category}</td>
         <td>{this.props.transaction.memo}</td>
         <td style={{ textAlign: 'right' }}>
-          {accounting.formatMoney(this.props.transaction.outflow, '$')}
+          {accounting.formatMoney(this.props.transaction.outflow(), '$')}
         </td>
         <td style={{ textAlign: 'right' }}>
-          {accounting.formatMoney(this.props.transaction.inflow, '$')}
+          {accounting.formatMoney(this.props.transaction.inflow(), '$')}
         </td>
       </tr>
     );

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,7 @@
+function ParseError(message) {
+  this.message = `Parse error: ${message}`;
+}
+ParseError.prototype = Object.create(Error.prototype);
+ParseError.prototype.constructor = ParseError;
+
+export default { ParseError };

--- a/test/MutableTransactionRow.jsx
+++ b/test/MutableTransactionRow.jsx
@@ -71,7 +71,6 @@ describe('<MutableTransactionRow />', function () {
         category: 'Restaurants',
         memo: 'yay noodles',
         outflow: 23,
-        inflow: 19.89,
       });
       const wrapper = createWrapper({ initialTransaction });
 
@@ -83,7 +82,7 @@ describe('<MutableTransactionRow />', function () {
         memo: 'yay noodles',
         // TODO: This should be 23.00.
         outflow: '23',
-        inflow: '19.89',
+        inflow: '0',
         submit: 'Submit',
       };
       validateFields(wrapper, expectedFields);
@@ -122,7 +121,7 @@ describe('<MutableTransactionRow />', function () {
         category: 'Restaurants',
         memo: 'yay noodles',
         outflow: '23.00',
-        inflow: '19.89',
+        inflow: '0',
       };
       setFields(wrapper, fields);
 
@@ -137,8 +136,7 @@ describe('<MutableTransactionRow />', function () {
         payee: 'Mu Ramen',
         category: 'Restaurants',
         memo: 'yay noodles',
-        outflow: 23,
-        inflow: 19.89,
+        amountMinor: -2300,
       };
       assert.deepEqual(receivedData, expectedData);
     });
@@ -152,7 +150,6 @@ describe('<MutableTransactionRow />', function () {
         category: 'Restaurants',
         memo: 'yay noodles',
         outflow: 23,
-        inflow: 19.89,
       });
 
       let receivedData = null;
@@ -170,7 +167,7 @@ describe('<MutableTransactionRow />', function () {
         category: 'Alcohol',
         memo: 'yay sake',
         outflow: '100.00',
-        inflow: '200.00',
+        inflow: '0',
       };
       setFields(wrapper, newFields);
 
@@ -185,8 +182,7 @@ describe('<MutableTransactionRow />', function () {
         payee: 'Hi-Collar',
         category: 'Alcohol',
         memo: 'yay sake',
-        outflow: 100,
-        inflow: 200,
+        amountMinor: -10000,
       };
       assert.deepEqual(receivedData, expectedData);
     });

--- a/test/MutableTransactionRow.jsx
+++ b/test/MutableTransactionRow.jsx
@@ -44,19 +44,19 @@ describe('<MutableTransactionRow />', function () {
     };
 
     it('without initialTransaction', function () {
-      const getDateStub = sinon.stub(MutableTransactionRow, 'getDate');
+      const getDateStub = sandbox.stub(MutableTransactionRow, 'getDate');
       getDateStub.returns('2017-01-01');
 
       const wrapper = createWrapper();
 
       const expectedFields = {
         account: '',
-        dateMs: '2017-01-01',
+        date: '2017-01-01',
         payee: '',
         category: '',
         memo: '',
-        outflow: '0',
-        inflow: '0',
+        outflow: '',
+        inflow: '',
         submit: 'Submit',
       };
       validateFields(wrapper, expectedFields);
@@ -77,7 +77,7 @@ describe('<MutableTransactionRow />', function () {
 
       const expectedFields = {
         account: 'Cash',
-        dateMs: '2017-01-01',
+        date: '2017-01-01',
         payee: 'Mu Ramen',
         category: 'Restaurants',
         memo: 'yay noodles',
@@ -93,6 +93,7 @@ describe('<MutableTransactionRow />', function () {
   describe('handles submission', function () {
     const setField = (wrapper, name, value) => {
       const field = wrapper.find({ name });
+      assert.lengthOf(field, 1, `Couldn't find field: ${name}`);
       const event = {
         target: {
           name,
@@ -109,16 +110,13 @@ describe('<MutableTransactionRow />', function () {
     };
 
     it('without initialTransaction', function () {
-      const getUUIDStub = sinon.stub(MutableTransactionRow, 'getUUID');
-      getUUIDStub.returns('fake-uuid');
-
       let receivedData = null;
       const handler = (data) => { receivedData = data; };
       const wrapper = createWrapper({ submitHandler: handler });
 
       // Edit fields.
       const fields = {
-        dateMs: '2017-01-01',
+        date: '2017-01-01',
         account: 'Cash',
         payee: 'Mu Ramen',
         category: 'Restaurants',
@@ -133,7 +131,7 @@ describe('<MutableTransactionRow />', function () {
 
       // Make sure handler() is called with the right data.
       const expectedData = {
-        id: 'fake-uuid',
+        id: null,
         dateMs: 1483228800000,
         account: 'Cash',
         payee: 'Mu Ramen',
@@ -166,7 +164,7 @@ describe('<MutableTransactionRow />', function () {
 
       // Edit fields.
       const newFields = {
-        dateMs: '2017-01-03',
+        date: '2017-01-03',
         account: 'Chase Sapphire Reserved',
         payee: 'Hi-Collar',
         category: 'Alcohol',

--- a/test/MutableTransactionRow.jsx
+++ b/test/MutableTransactionRow.jsx
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 
 import MutableTransactionRow from '../src/MutableTransactionRow';
 import Transaction from '../src/Transaction';
+import errors from '../src/errors';
 
 describe('<MutableTransactionRow />', function () {
   let sandbox;
@@ -70,7 +71,7 @@ describe('<MutableTransactionRow />', function () {
         payee: 'Mu Ramen',
         category: 'Restaurants',
         memo: 'yay noodles',
-        outflow: 23,
+        amountMinor: -2300,
       });
       const wrapper = createWrapper({ initialTransaction });
 
@@ -88,6 +89,58 @@ describe('<MutableTransactionRow />', function () {
       validateFields(wrapper, expectedFields);
     });
   });
+
+  describe('#parseAmountMinor', function () {
+    it('fails if both inflow and outflow are given', function () {
+      assert.throws(
+        () => { MutableTransactionRow.parseAmountMinor('100.00', '200.30'); },
+        errors.ParseError, /Both outflow.*and inflow.* can't be given/);
+    });
+
+    it('fails if inflow is negative', function () {
+      assert.throws(
+        () => { MutableTransactionRow.parseAmountMinor('-100.30', ''); },
+        errors.ParseError, /inflow can't be negative.*/);
+    });
+
+    it('fails if outflow is negative', function () {
+      assert.throws(
+        () => { MutableTransactionRow.parseAmountMinor('', '-100.30'); },
+        errors.ParseError, /outflow can't be negative.*/);
+    });
+
+    it('fails if inflow is not a number', function () {
+      assert.throws(
+        () => { MutableTransactionRow.parseAmountMinor('hello', ''); },
+        errors.ParseError, /inflow is not a number: hello/);
+    });
+
+    it('fails if outflow is not a number', function () {
+      assert.throws(
+        () => { MutableTransactionRow.parseAmountMinor('', 'hello'); },
+        errors.ParseError, /outflow is not a number: hello/);
+    });
+
+    it('parses valid inflow and empty outflow', function () {
+      const result = MutableTransactionRow.parseAmountMinor('100.30', '');
+      assert.equal(result, 10030);
+    });
+
+    it('parses valid inflow and zero outflow', function () {
+      const result = MutableTransactionRow.parseAmountMinor('100.30', '0');
+      assert.equal(result, 10030);
+    });
+
+    it('parses empty inflow and valid outflow', function () {
+      const result = MutableTransactionRow.parseAmountMinor('', '100.30');
+      assert.equal(result, -10030);
+    });
+
+    it('parses zero inflow and valid outflow', function () {
+      const result = MutableTransactionRow.parseAmountMinor('0', '100.30');
+      assert.equal(result, -10030);
+    });
+  });  // #parseAmountMinor
 
   describe('handles submission', function () {
     const setField = (wrapper, name, value) => {
@@ -149,7 +202,7 @@ describe('<MutableTransactionRow />', function () {
         payee: 'Mu Ramen',
         category: 'Restaurants',
         memo: 'yay noodles',
-        outflow: 23,
+        amountMinor: -2300,
       });
 
       let receivedData = null;

--- a/test/Transaction.jsx
+++ b/test/Transaction.jsx
@@ -1,0 +1,81 @@
+import { assert } from 'chai';
+
+import LoonyInternalError from '../src/LoonyInternalError';
+import Transaction from '../src/Transaction';
+
+describe('Transaction', function () {
+  describe('ctor', function () {
+    it('both inflow and outflow cannot be specified', function () {
+      assert.throws(
+        /* eslint-disable no-new */
+        () => { new Transaction({ inflow: 1.0, outflow: 200 }); },
+        /* eslint-enable no-new */
+        LoonyInternalError, /Both outflow.*and inflow/);
+    });
+
+    it('both inflow and outflow can be zero', function () {
+      const tx = new Transaction({ outflow: 0, inflow: 0 });
+      assert.equal(tx.amountMinor, 0);
+    });
+
+    it('outflow must be non-negative', function () {
+      assert.throws(
+        /* eslint-disable no-new */
+        () => { new Transaction({ outflow: -100 }); },
+        /* eslint-enable no-new */
+        LoonyInternalError, /outflow can't be negative/);
+    });
+
+    it('inflow must be non-negative', function () {
+      assert.throws(
+        /* eslint-disable no-new */
+        () => { new Transaction({ inflow: -100 }); },
+        /* eslint-enable no-new */
+        LoonyInternalError, /inflow can't be negative/);
+    });
+
+    it('amountMinor parsed from inflow', function () {
+      const tx = new Transaction({ inflow: 200 });
+      assert.equal(tx.amountMinor, 20000);
+    });
+
+    it('amountMinor parsed from outflow', function () {
+      const tx = new Transaction({ outflow: 200 });
+      assert.equal(tx.amountMinor, -20000);
+    });
+  });  // ctor
+
+  describe('outflow', function () {
+    it('returns if outflow given', function () {
+      const tx = new Transaction({ outflow: 200 });
+      assert.equal(tx.outflow(), 200);
+    });
+
+    it('returns zero with zero outflow', function () {
+      const tx = new Transaction({ outflow: 0 });
+      assert.equal(tx.outflow(), 0);
+    });
+
+    it('returns zero if only inflow given', function () {
+      const tx = new Transaction({ inflow: 200 });
+      assert.equal(tx.outflow(), 0);
+    });
+  });  // outflow
+
+  describe('inflow', function () {
+    it('returns if inflow given', function () {
+      const tx = new Transaction({ inflow: 200 });
+      assert.equal(tx.inflow(), 200);
+    });
+
+    it('returns zero with zero inflow', function () {
+      const tx = new Transaction({ inflow: 0 });
+      assert.equal(tx.inflow(), 0);
+    });
+
+    it('returns zero if only outflow given', function () {
+      const tx = new Transaction({ outflow: 200 });
+      assert.equal(tx.inflow(), 0);
+    });
+  });  // inflow
+});

--- a/test/Transaction.jsx
+++ b/test/Transaction.jsx
@@ -1,80 +1,38 @@
 import { assert } from 'chai';
 
-import LoonyInternalError from '../src/LoonyInternalError';
 import Transaction from '../src/Transaction';
 
 describe('Transaction', function () {
-  describe('ctor', function () {
-    it('both inflow and outflow cannot be specified', function () {
-      assert.throws(
-        /* eslint-disable no-new */
-        () => { new Transaction({ inflow: 1.0, outflow: 200 }); },
-        /* eslint-enable no-new */
-        LoonyInternalError, /Both outflow.*and inflow/);
-    });
-
-    it('both inflow and outflow can be zero', function () {
-      const tx = new Transaction({ outflow: 0, inflow: 0 });
-      assert.equal(tx.amountMinor, 0);
-    });
-
-    it('outflow must be non-negative', function () {
-      assert.throws(
-        /* eslint-disable no-new */
-        () => { new Transaction({ outflow: -100 }); },
-        /* eslint-enable no-new */
-        LoonyInternalError, /outflow can't be negative/);
-    });
-
-    it('inflow must be non-negative', function () {
-      assert.throws(
-        /* eslint-disable no-new */
-        () => { new Transaction({ inflow: -100 }); },
-        /* eslint-enable no-new */
-        LoonyInternalError, /inflow can't be negative/);
-    });
-
-    it('amountMinor parsed from inflow', function () {
-      const tx = new Transaction({ inflow: 200 });
-      assert.equal(tx.amountMinor, 20000);
-    });
-
-    it('amountMinor parsed from outflow', function () {
-      const tx = new Transaction({ outflow: 200 });
-      assert.equal(tx.amountMinor, -20000);
-    });
-  });  // ctor
-
   describe('outflow', function () {
-    it('returns if outflow given', function () {
-      const tx = new Transaction({ outflow: 200 });
+    it('returns with negative amountMinor', function () {
+      const tx = new Transaction({ amountMinor: -20000 });
       assert.equal(tx.outflow(), 200);
     });
 
-    it('returns zero with zero outflow', function () {
-      const tx = new Transaction({ outflow: 0 });
+    it('returns zero with zero amountMinor', function () {
+      const tx = new Transaction({ amountMinor: 0 });
       assert.equal(tx.outflow(), 0);
     });
 
-    it('returns zero if only inflow given', function () {
-      const tx = new Transaction({ inflow: 200 });
+    it('returns zero with positive amountMinor', function () {
+      const tx = new Transaction({ amountMinor: 20000 });
       assert.equal(tx.outflow(), 0);
     });
   });  // outflow
 
   describe('inflow', function () {
-    it('returns if inflow given', function () {
-      const tx = new Transaction({ inflow: 200 });
+    it('returns with positive amountMinor', function () {
+      const tx = new Transaction({ amountMinor: 20000 });
       assert.equal(tx.inflow(), 200);
     });
 
-    it('returns zero with zero inflow', function () {
-      const tx = new Transaction({ inflow: 0 });
+    it('returns zero with zero amountMinor', function () {
+      const tx = new Transaction({ amountMinor: 0 });
       assert.equal(tx.inflow(), 0);
     });
 
-    it('returns zero if only outflow given', function () {
-      const tx = new Transaction({ outflow: 200 });
+    it('returns zero with negative amountMinor', function () {
+      const tx = new Transaction({ amountMinor: -20000 });
       assert.equal(tx.inflow(), 0);
     });
   });  // inflow

--- a/test/TransactionRow.jsx
+++ b/test/TransactionRow.jsx
@@ -29,7 +29,6 @@ describe('<TransactionRow />', function () {
         category: 'Restaurants',
         memo: 'yay noodles',
         outflow: 23,
-        inflow: 19.89,
       });
       const wrapper = createWrapper(transaction);
 
@@ -44,7 +43,7 @@ describe('<TransactionRow />', function () {
         'Restaurants',
         'yay noodles',
         '$23.00',
-        '$19.89',
+        '$0.00',
       ];
       assert.deepEqual(cells, expectedCells);
     });
@@ -58,7 +57,6 @@ describe('<TransactionRow />', function () {
         category: 'Restaurants',
         memo: 'yay noodles',
         outflow: 23,
-        inflow: 19.89,
       });
       const wrapper = createWrapper(transaction);
 
@@ -75,7 +73,6 @@ describe('<TransactionRow />', function () {
         category: 'Restaurants',
         memo: 'yay noodles',
         outflow: 23,
-        inflow: 19.89,
       });
       const wrapper = createWrapper(transaction);
 

--- a/test/TransactionRow.jsx
+++ b/test/TransactionRow.jsx
@@ -28,7 +28,7 @@ describe('<TransactionRow />', function () {
         payee: 'Mu Ramen',
         category: 'Restaurants',
         memo: 'yay noodles',
-        outflow: 23,
+        amountMinor: -2300,
       });
       const wrapper = createWrapper(transaction);
 


### PR DESCRIPTION
Add inflow() and outflow() methods that utilize amountMinor. Change components
to use these new methods.

Fix tests to not pass both inflow and outflow fields to Transaction().

Issue: #15