### PR TITLE
Change MutableTransactionRow to not store a Transaction in state

### DIFF
--- a/src/MutableTransactionRow.jsx
+++ b/src/MutableTransactionRow.jsx
@@ -1,6 +1,5 @@
 import moment from 'moment';
 import React from 'react';
-import uuid from 'uuid';
 
 import Transaction from './Transaction';
 
@@ -10,27 +9,35 @@ export default class MutableTransactionRow extends React.Component {
     return moment().format('YYYY-MM-DD');
   }
 
-  // Test seam.
-  static getUUID() {
-    return uuid.v4();
-  }
-
-  static getEmptyTransaction() {
-    return new Transaction({
-      id: MutableTransactionRow.getUUID(),
-      dateMs: MutableTransactionRow.getDate(),
-    });
+  static getEmptyState() {
+    return {
+      id: null,
+      account: '',
+      date: MutableTransactionRow.getDate(),
+      payee: '',
+      category: '',
+      memo: '',
+      outflow: '',
+      inflow: '',
+    };
   }
 
   constructor(props) {
     super(props);
 
-    this.state = {};
-
     if (this.props.initialTransaction === null) {
-      this.state.transaction = MutableTransactionRow.getEmptyTransaction();
+      this.state = MutableTransactionRow.getEmptyState();
     } else {
-      this.state.transaction = this.props.initialTransaction;
+      this.state = {
+        id: this.props.initialTransaction.id,
+        account: this.props.initialTransaction.account,
+        date: this.props.initialTransaction.prettyDate(),
+        payee: this.props.initialTransaction.payee,
+        category: this.props.initialTransaction.category,
+        memo: this.props.initialTransaction.memo,
+        outflow: this.props.initialTransaction.outflow,
+        inflow: this.props.initialTransaction.inflow,
+      };
     }
 
     this.handleInputChange = this.handleInputChange.bind(this);
@@ -40,26 +47,26 @@ export default class MutableTransactionRow extends React.Component {
   handleInputChange(event) {
     const target = event.target;
     const { name, value } = target;
-    this.setState((prevState) => {
-      const tx = prevState.transaction;
-      tx[name] = value;
-      return { tx };
-    });
+    this.setState({ [name]: value });
   }
 
   handleSubmit() {
-    const tx = this.state.transaction;
-
-    // Parse fields into our actual desired types.
-    tx.dateMs = moment.utc(tx.dateMs, 'YYYY-MM-DD').valueOf();
-    // TODO: Stop using floats to represent money.
-    tx.outflow = parseFloat(tx.outflow);
-    tx.inflow = parseFloat(tx.inflow);
+    const tx = new Transaction({
+      id: this.state.id,
+      account: this.state.account,
+      dateMs: moment.utc(this.state.date, 'YYYY-MM-DD').valueOf(),
+      payee: this.state.payee,
+      category: this.state.category,
+      memo: this.state.memo,
+      // TODO: Stop using floats to represent money.
+      outflow: parseFloat(this.state.outflow),
+      inflow: parseFloat(this.state.inflow),
+    });
 
     this.props.submitHandler(tx);
     // Clear the state so this component can be reused (e.g. by
     // AddTransactionRow).
-    this.state.transaction = MutableTransactionRow.getEmptyTransaction();
+    this.setState(MutableTransactionRow.getEmptyState());
   }
 
   render() {
@@ -72,16 +79,16 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="account"
             placeholder="Account"
-            value={this.state.transaction.account}
+            value={this.state.account}
             onChange={this.handleInputChange}
           />
         </td>
         <td>
           <input
             type="date"
-            name="dateMs"
+            name="date"
             placeholder="Date"
-            value={this.state.transaction.prettyDate()}
+            value={this.state.date}
             onChange={this.handleInputChange}
           />
         </td>
@@ -90,7 +97,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="payee"
             placeholder="Payee"
-            value={this.state.transaction.payee}
+            value={this.state.payee}
             onChange={this.handleInputChange}
           />
         </td>
@@ -99,7 +106,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="category"
             placeholder="Category"
-            value={this.state.transaction.category}
+            value={this.state.category}
             onChange={this.handleInputChange}
           />
         </td>
@@ -108,7 +115,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="memo"
             placeholder="Memo"
-            value={this.state.transaction.memo}
+            value={this.state.memo}
             onChange={this.handleInputChange}
           />
         </td>
@@ -117,7 +124,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="outflow"
             placeholder="Outflow"
-            value={this.state.transaction.outflow}
+            value={this.state.outflow}
             onChange={this.handleInputChange}
           />
         </td>
@@ -126,7 +133,7 @@ export default class MutableTransactionRow extends React.Component {
             type="text"
             name="inflow"
             placeholder="Inflow"
-            value={this.state.transaction.inflow}
+            value={this.state.inflow}
             onChange={this.handleInputChange}
           />
         </td>

--- a/test/MutableTransactionRow.jsx
+++ b/test/MutableTransactionRow.jsx
@@ -44,19 +44,19 @@ describe('<MutableTransactionRow />', function () {
     };
 
     it('without initialTransaction', function () {
-      const getDateStub = sinon.stub(MutableTransactionRow, 'getDate');
+      const getDateStub = sandbox.stub(MutableTransactionRow, 'getDate');
       getDateStub.returns('2017-01-01');
 
       const wrapper = createWrapper();
 
       const expectedFields = {
         account: '',
-        dateMs: '2017-01-01',
+        date: '2017-01-01',
         payee: '',
         category: '',
         memo: '',
-        outflow: '0',
-        inflow: '0',
+        outflow: '',
+        inflow: '',
         submit: 'Submit',
       };
       validateFields(wrapper, expectedFields);
@@ -77,7 +77,7 @@ describe('<MutableTransactionRow />', function () {
 
       const expectedFields = {
         account: 'Cash',
-        dateMs: '2017-01-01',
+        date: '2017-01-01',
         payee: 'Mu Ramen',
         category: 'Restaurants',
         memo: 'yay noodles',
@@ -93,6 +93,7 @@ describe('<MutableTransactionRow />', function () {
   describe('handles submission', function () {
     const setField = (wrapper, name, value) => {
       const field = wrapper.find({ name });
+      assert.lengthOf(field, 1, `Couldn't find field: ${name}`);
       const event = {
         target: {
           name,
@@ -109,16 +110,13 @@ describe('<MutableTransactionRow />', function () {
     };
 
     it('without initialTransaction', function () {
-      const getUUIDStub = sinon.stub(MutableTransactionRow, 'getUUID');
-      getUUIDStub.returns('fake-uuid');
-
       let receivedData = null;
       const handler = (data) => { receivedData = data; };
       const wrapper = createWrapper({ submitHandler: handler });
 
       // Edit fields.
       const fields = {
-        dateMs: '2017-01-01',
+        date: '2017-01-01',
         account: 'Cash',
         payee: 'Mu Ramen',
         category: 'Restaurants',
@@ -133,7 +131,7 @@ describe('<MutableTransactionRow />', function () {
 
       // Make sure handler() is called with the right data.
       const expectedData = {
-        id: 'fake-uuid',
+        id: null,
         dateMs: 1483228800000,
         account: 'Cash',
         payee: 'Mu Ramen',
@@ -166,7 +164,7 @@ describe('<MutableTransactionRow />', function () {
 
       // Edit fields.
       const newFields = {
-        dateMs: '2017-01-03',
+        date: '2017-01-03',
         account: 'Chase Sapphire Reserved',
         payee: 'Hi-Collar',
         category: 'Alcohol',


### PR DESCRIPTION
User inputs in a MutableTransactionRow don't necessarily map 1:1 with the
fields in a Transaction object; stop abusing Transaction objects as temporary
storage for user input. This will become especially true now that we're
starting to implement the actual data model: e.g. the 'account' and 'category'
fields will point to actual objects instead of being strings.

More immediately though, this change is required to start storing amountMinor
in Transaction instead of separate 'inflow' and 'outflow' fields.

Also stop passing 'id' to the ctor of Transaction when creating new
transactions. Population of the Transaction id is handled by addTransaction
since we use Firebase keys as the Transaction id.

Yes, this basically undoes commit 7efe39846b01c15cddb1ce98361cb1c0fe3dab63.

Issue: #15